### PR TITLE
Add /cv-parse route to proxy for CV parser worker

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export interface Env {
     TEXT_API_URL: string;
     SEARCH_API_URL?: string;  // Optional - falls back to OPENALEX_API_URL if not set
     CONTENT_WORKER: Fetcher;  // Service binding to openalex-content-worker
+    CV_PARSER?: Fetcher;      // Service binding to openalex-cv-parser
 }
 
 // In-memory cache for API key validation
@@ -314,6 +315,18 @@ export default {
                 error: "API key required",
                 message: "Changefile downloads require an API key. Get one at https://openalex.org/pricing"
             });
+        }
+
+        // Route /cv-parse/* to CV parser worker
+        if (env.CV_PARSER && /^\/cv-parse(\/|$)/i.test(url.pathname)) {
+            const cvPath = url.pathname.replace(/^\/cv-parse/, '') || '/';
+            const cvUrl = new URL(req.url);
+            cvUrl.pathname = cvPath;
+            const cvResponse = await env.CV_PARSER.fetch(new Request(cvUrl, req));
+            return addCorsHeaders(new Response(cvResponse.body, {
+                status: cvResponse.status,
+                headers: cvResponse.headers,
+            }));
         }
 
         // Route content.openalex.org/* OR /content/* to content worker

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -55,6 +55,10 @@
 		{
 			"binding": "CONTENT_WORKER",
 			"service": "openalex-content-worker"
+		},
+		{
+			"binding": "CV_PARSER",
+			"service": "openalex-cv-parser"
 		}
 	]
 }


### PR DESCRIPTION
Routes /cv-parse/* requests to the openalex-cv-parser Cloudflare Worker via a service binding. The binding is optional so the proxy continues to work before the CV parser worker is deployed.