### PR TITLE
UI-provenance token: Turnstile-minted HMAC marker (oxjob #338 P-A)

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -62,6 +62,10 @@ export function logAnalytics(params: {
     rateLimitRemaining: number;
     endpointType?: string;
     creditCost?: number;
+    // oxjob #338 Phase 5a: did this request carry a valid UI-provenance token?
+    // Trustworthy replacement for the spoofable `mailto=ui@openalex.org` marker
+    // when splitting UI vs API traffic. Defaults to false.
+    trustedUi?: boolean;
     // A cloned upstream response, passed in only on the sampled fraction. We
     // parse `meta.db_response_time_ms` out of it inside ctx.waitUntil so the
     // body-read never blocks the user response.
@@ -113,7 +117,8 @@ export function logAnalytics(params: {
                         params.rateLimit,           // double3: rate limit (credits)
                         params.rateLimitRemaining,  // double4: credits remaining
                         params.creditCost ?? 1,     // double5: credits consumed for this request
-                        esTookMs                    // double6: ES `meta.db_response_time_ms` (-1 = not sampled / N/A)
+                        esTookMs,                   // double6: ES `meta.db_response_time_ms` (-1 = not sampled / N/A)
+                        params.trustedUi ? 1 : 0    // double7: valid UI-provenance token present (oxjob #338)
                     ]
                 });
             } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { logAnalytics, shouldSampleEsTook } from "./analytics";
 import { classifyEndpoint, EndpointClassification } from "./endpointClassifier";
 import { f1Reason, f1Message } from "./f1Validation";
 import { isChangefilesBrowsePath, isChangefileDownloadPath } from "./changefilesPaths";
+import { mintUiToken, verifyUiToken, verifyTurnstile } from "./uiToken";
 
 export interface Env {
     HYPERDRIVE: Hyperdrive;
@@ -14,7 +15,19 @@ export interface Env {
     SEARCH_API_URL?: string;  // Optional - falls back to OPENALEX_API_URL if not set
     CONTENT_WORKER: Fetcher;  // Service binding to openalex-content-worker
     CV_PARSER?: Fetcher;      // Service binding to openalex-cv-parser
+    // oxjob #338 Phase 5a — UI-provenance token (Turnstile-minted). Both optional:
+    // if either is unset the feature is inert (no mint; every request just tags
+    // trustedUi=false). It can NEVER block traffic. Set as Worker secrets.
+    TURNSTILE_SECRET?: string;       // Cloudflare Turnstile secret (siteverify)
+    UI_TOKEN_HMAC_SECRET?: string;   // HMAC signing secret for the minted token
 }
+
+// oxjob #338: minted UI-provenance tokens live 30 min; the GUI re-mints on expiry.
+const UI_TOKEN_TTL_SECONDS = 1800;
+// Header the GUI attaches the minted token on (mirrors getApiKeyFromRequest's
+// header style). Chosen over a query param so it stays out of URL logs/cache
+// keys and isn't copy-pasteable from a shared URL the way `mailto` was.
+const UI_TOKEN_HEADER = "X-OpenAlex-UI";
 
 type ThrottleScope = 'user' | 'org';
 
@@ -79,6 +92,51 @@ export default {
                 headers: cvResponse.headers,
             }));
         }
+
+        // UI-provenance token mint (oxjob #338 Phase 5a). The GUI POSTs a
+        // Cloudflare Turnstile solve; we verify it server-side and mint a
+        // short-TTL HMAC token the GUI then sends back on the X-OpenAlex-UI
+        // header. No API key needed (anonymous SPA), so it sits before API-key
+        // validation, like /cv-parse. This endpoint ONLY issues a provenance
+        // marker — it grants no quota or access, so a failed/absent mint just
+        // means the GUI's later requests are tagged untrusted, never blocked.
+        const uiTokenPath = url.pathname.replace(/^\/+|\/+$/g, '').toLowerCase();
+        if (uiTokenPath === 'ui-token') {
+            if (req.method !== 'POST') {
+                return json(405, { error: "Method Not Allowed", message: "POST a Turnstile token to /ui-token" });
+            }
+            if (!env.TURNSTILE_SECRET || !env.UI_TOKEN_HMAC_SECRET) {
+                // Feature not provisioned yet — say so plainly; the GUI treats a
+                // non-200 here as "no UI token this session" and carries on.
+                return json(503, { error: "UI token minting not configured" });
+            }
+            let turnstileResponse: string | null = null;
+            try {
+                const body = await req.json() as { turnstileResponse?: string; "cf-turnstile-response"?: string };
+                turnstileResponse = body.turnstileResponse || body["cf-turnstile-response"] || null;
+            } catch { /* fall through to the missing-token branch */ }
+
+            const ts = await verifyTurnstile(
+                turnstileResponse,
+                env.TURNSTILE_SECRET,
+                req.headers.get("CF-Connecting-IP"),
+            );
+            if (!ts.success) {
+                return json(403, { error: "Turnstile verification failed", errorCodes: ts.errorCodes });
+            }
+            const token = await mintUiToken(env.UI_TOKEN_HMAC_SECRET, Date.now(), UI_TOKEN_TTL_SECONDS);
+            return json(200, { token, expiresIn: UI_TOKEN_TTL_SECONDS });
+        }
+
+        // Is this request carrying a valid UI-provenance token? Provenance only:
+        // NEVER gates the request — just tags analytics so the UI/non-UI split
+        // (relied on by #338 + #340) stops being spoofable via `mailto`.
+        const uiTokenVerify = await verifyUiToken(
+            req.headers.get(UI_TOKEN_HEADER),
+            env.UI_TOKEN_HMAC_SECRET,
+            Date.now(),
+        );
+        const trustedUi = uiTokenVerify.valid;
 
         const apiKey = getApiKeyFromRequest(req);
         let hasValidApiKey = false;
@@ -508,7 +566,8 @@ export default {
                 rateLimit: limit,
                 rateLimitRemaining: adjustedRemaining,
                 endpointType: classification.type,
-                creditCost: actualCost
+                creditCost: actualCost,
+                trustedUi
             });
 
             return finalResponse;
@@ -677,6 +736,7 @@ export default {
             rateLimitRemaining: rateLimitResult.remaining ?? 0,
             endpointType: classification.type,
             creditCost,
+            trustedUi,
             responseForEsTook: sampledResponseForAnalytics
         });
 
@@ -849,7 +909,7 @@ function getCorsHeaders(): Headers {
     const headers = new Headers();
     headers.set("Access-Control-Allow-Origin", "*");
     headers.set("Access-Control-Allow-Methods", "GET, HEAD, POST, OPTIONS");
-    headers.set("Access-Control-Allow-Headers", "Accept, Accept-Language, Accept-Encoding, Authorization, Content-Type");
+    headers.set("Access-Control-Allow-Headers", "Accept, Accept-Language, Accept-Encoding, Authorization, Content-Type, X-OpenAlex-UI");
     headers.set("Access-Control-Expose-Headers", "Cache-Control, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Onetime-Remaining, X-RateLimit-Credits-Used, X-RateLimit-Credits-Required, X-RateLimit-Reset, X-RateLimit-Limit-USD, X-RateLimit-Remaining-USD, X-RateLimit-Prepaid-Remaining-USD, X-RateLimit-Cost-USD, X-RateLimit-Cost-Required-USD, Retry-After");
     return headers;
 }

--- a/src/uiToken.test.ts
+++ b/src/uiToken.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { mintUiToken, verifyUiToken, verifyTurnstile } from './uiToken';
+
+const SECRET = 'test-hmac-secret-do-not-use-in-prod';
+const TTL = 1800; // 30 min
+const NOW = 1_700_000_000_000; // fixed epoch ms for determinism
+
+describe('uiToken mint/verify', () => {
+    it('mints a token that verifies as valid within its TTL', async () => {
+        const tok = await mintUiToken(SECRET, NOW, TTL);
+        const res = await verifyUiToken(tok, SECRET, NOW + 1000);
+        expect(res.valid).toBe(true);
+        expect(res.payload?.v).toBe(1);
+        expect(res.payload?.exp).toBe(Math.floor(NOW / 1000) + TTL);
+    });
+
+    it('rejects an expired token', async () => {
+        const tok = await mintUiToken(SECRET, NOW, TTL);
+        const res = await verifyUiToken(tok, SECRET, NOW + (TTL + 1) * 1000);
+        expect(res.valid).toBe(false);
+        expect(res.reason).toBe('expired');
+    });
+
+    it('rejects a token signed with a different secret (forgery)', async () => {
+        const tok = await mintUiToken('attacker-secret', NOW, TTL);
+        const res = await verifyUiToken(tok, SECRET, NOW + 1000);
+        expect(res.valid).toBe(false);
+        expect(res.reason).toBe('bad_signature');
+    });
+
+    it('rejects a tampered payload (signature no longer matches)', async () => {
+        const tok = await mintUiToken(SECRET, NOW, TTL);
+        const [body, sig] = tok.split('.');
+        // Flip a char in the body; the original signature won't match.
+        const tampered = body.slice(0, -1) + (body.slice(-1) === 'A' ? 'B' : 'A') + '.' + sig;
+        const res = await verifyUiToken(tampered, SECRET, NOW + 1000);
+        expect(res.valid).toBe(false);
+        expect(res.reason).toBe('bad_signature');
+    });
+
+    it('treats malformed / empty / null tokens as untrusted, never throws', async () => {
+        for (const bad of [null, undefined, '', 'no-dot', '.', 'a.', '.b']) {
+            const res = await verifyUiToken(bad as string, SECRET, NOW);
+            expect(res.valid).toBe(false);
+            expect(res.reason).toBe('malformed');
+        }
+    });
+
+    it('reports no_secret when the server secret is unset (fail-safe, not crash)', async () => {
+        const res = await verifyUiToken('whatever.sig', undefined, NOW);
+        expect(res.valid).toBe(false);
+        expect(res.reason).toBe('no_secret');
+    });
+
+    it('each mint is unique (random nonce) but all verify', async () => {
+        const a = await mintUiToken(SECRET, NOW, TTL);
+        const b = await mintUiToken(SECRET, NOW, TTL);
+        expect(a).not.toBe(b);
+        expect((await verifyUiToken(a, SECRET, NOW)).valid).toBe(true);
+        expect((await verifyUiToken(b, SECRET, NOW)).valid).toBe(true);
+    });
+});
+
+describe('verifyTurnstile', () => {
+    const okFetch = (async () =>
+        new Response(JSON.stringify({ success: true }), { status: 200 })) as unknown as typeof fetch;
+    const failFetch = (async () =>
+        new Response(JSON.stringify({ success: false, 'error-codes': ['invalid-input-response'] }), { status: 200 })) as unknown as typeof fetch;
+    const throwFetch = (async () => { throw new Error('network'); }) as unknown as typeof fetch;
+
+    it('returns success when siteverify says success', async () => {
+        const r = await verifyTurnstile('ts-response', 'secret', '1.2.3.4', okFetch);
+        expect(r.success).toBe(true);
+    });
+
+    it('returns failure when siteverify rejects', async () => {
+        const r = await verifyTurnstile('ts-response', 'secret', '1.2.3.4', failFetch);
+        expect(r.success).toBe(false);
+        expect(r.errorCodes).toContain('invalid-input-response');
+    });
+
+    it('fails closed (no throw) on a missing turnstile response or secret', async () => {
+        expect((await verifyTurnstile(null, 'secret', null, okFetch)).success).toBe(false);
+        expect((await verifyTurnstile('ts', undefined, null, okFetch)).success).toBe(false);
+    });
+
+    it('fails closed on a network error', async () => {
+        const r = await verifyTurnstile('ts', 'secret', null, throwFetch);
+        expect(r.success).toBe(false);
+        expect(r.errorCodes).toContain('verify-failed');
+    });
+});

--- a/src/uiToken.ts
+++ b/src/uiToken.ts
@@ -1,0 +1,166 @@
+// UI-provenance token (oxjob #338, Phase 5a / "P-A").
+//
+// Purpose: give the openalex.org GUI an *unforgeable* "this request came from
+// the real web UI" signal, replacing the trivially-spoofable
+// `mailto=ui@openalex.org` query marker. Bots copy the mailto string verbatim
+// to disguise themselves as UI traffic, which poisons the UI-vs-API analytics
+// split that #338 and #340 both reason about.
+//
+// Shape: the GUI passes a Cloudflare Turnstile solve to `POST /ui-token`; we
+// verify it server-side (secret never ships to the browser) and mint a short-
+// TTL HMAC token the GUI then attaches as the `X-OpenAlex-UI` header. The main
+// proxy path verifies the HMAC and tags the request `trustedUi` in analytics.
+//
+// HARD INVARIANT: this token is PROVENANCE, never AUTHORIZATION. A missing,
+// expired, or forged token must NEVER block, throttle, or downgrade an API
+// request — it only flips an analytics flag. The OpenAlex API stays wide open.
+//
+// Honest limitation (see work/phase5a-turnstile-design.md in oxjobs #338):
+// Turnstile is the same defense class as the Managed Challenge that the
+// AS132203 headless fleet already defeats, so this does not hard-stop
+// sophisticated bots from minting tokens. It kills the trivial string-copy
+// spoof and yields a far cleaner analytics signal; the ES-cost lever is #340.
+
+const TOKEN_VERSION = 1;
+const TURNSTILE_SITEVERIFY_URL =
+    "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+export interface UiTokenPayload {
+    v: number;      // token version
+    iat: number;    // issued-at (epoch seconds)
+    exp: number;    // expiry (epoch seconds)
+    nonce: string;  // random, makes each token unique (no replay value on its own)
+}
+
+export interface VerifyResult {
+    valid: boolean;
+    reason?: "malformed" | "bad_signature" | "expired" | "bad_version" | "no_secret";
+    payload?: UiTokenPayload;
+}
+
+// ---- base64url (no padding) over UTF-8 / bytes -----------------------------
+
+function bytesToB64url(bytes: Uint8Array): string {
+    let bin = "";
+    for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+    return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function b64urlToBytes(s: string): Uint8Array {
+    const b64 = s.replace(/-/g, "+").replace(/_/g, "/") + "===".slice((s.length + 3) % 4);
+    const bin = atob(b64);
+    const out = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+    return out;
+}
+
+function encodeJson(payload: UiTokenPayload): string {
+    return bytesToB64url(new TextEncoder().encode(JSON.stringify(payload)));
+}
+
+// ---- HMAC-SHA256 via Web Crypto (available in the Workers runtime) ---------
+
+async function hmac(secret: string, message: string): Promise<Uint8Array> {
+    const key = await crypto.subtle.importKey(
+        "raw",
+        new TextEncoder().encode(secret),
+        { name: "HMAC", hash: "SHA-256" },
+        false,
+        ["sign"],
+    );
+    const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(message));
+    return new Uint8Array(sig);
+}
+
+// Constant-time compare so signature checks don't leak via timing.
+function timingSafeEqual(a: string, b: string): boolean {
+    if (a.length !== b.length) return false;
+    let diff = 0;
+    for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+    return diff === 0;
+}
+
+// ---- mint / verify ---------------------------------------------------------
+
+/**
+ * Mint a signed UI-provenance token. `nonce` defaults to a fresh random value;
+ * pass one only in tests for determinism.
+ */
+export async function mintUiToken(
+    secret: string,
+    nowMs: number,
+    ttlSeconds: number,
+    nonce: string = crypto.randomUUID(),
+): Promise<string> {
+    const iat = Math.floor(nowMs / 1000);
+    const payload: UiTokenPayload = { v: TOKEN_VERSION, iat, exp: iat + ttlSeconds, nonce };
+    const body = encodeJson(payload);
+    const sig = bytesToB64url(await hmac(secret, body));
+    return `${body}.${sig}`;
+}
+
+/**
+ * Verify a UI-provenance token. Never throws — returns {valid:false, reason}
+ * on any problem so callers can treat every failure as simply "untrusted".
+ */
+export async function verifyUiToken(
+    token: string | null | undefined,
+    secret: string | undefined,
+    nowMs: number,
+): Promise<VerifyResult> {
+    if (!secret) return { valid: false, reason: "no_secret" };
+    if (!token || typeof token !== "string") return { valid: false, reason: "malformed" };
+
+    const dot = token.indexOf(".");
+    if (dot <= 0 || dot === token.length - 1) return { valid: false, reason: "malformed" };
+    const body = token.slice(0, dot);
+    const providedSig = token.slice(dot + 1);
+
+    const expectedSig = bytesToB64url(await hmac(secret, body));
+    if (!timingSafeEqual(providedSig, expectedSig)) return { valid: false, reason: "bad_signature" };
+
+    let payload: UiTokenPayload;
+    try {
+        payload = JSON.parse(new TextDecoder().decode(b64urlToBytes(body)));
+    } catch {
+        return { valid: false, reason: "malformed" };
+    }
+    if (payload.v !== TOKEN_VERSION) return { valid: false, reason: "bad_version" };
+    if (typeof payload.exp !== "number" || payload.exp * 1000 <= nowMs) {
+        return { valid: false, reason: "expired" };
+    }
+    return { valid: true, payload };
+}
+
+// ---- Turnstile siteverify --------------------------------------------------
+
+export interface TurnstileResult {
+    success: boolean;
+    errorCodes?: string[];
+}
+
+/**
+ * Validate a Turnstile client response against Cloudflare's siteverify API.
+ * `fetchImpl` is injectable for tests. Fails closed (success:false) on any
+ * network/parse error — a failed verify just means "no token minted", which is
+ * safe (the caller still serves API traffic; it's only the provenance mint).
+ */
+export async function verifyTurnstile(
+    turnstileResponse: string | null | undefined,
+    secret: string | undefined,
+    remoteIp: string | null,
+    fetchImpl: typeof fetch = fetch,
+): Promise<TurnstileResult> {
+    if (!secret || !turnstileResponse) return { success: false, errorCodes: ["missing-input"] };
+    try {
+        const form = new FormData();
+        form.append("secret", secret);
+        form.append("response", turnstileResponse);
+        if (remoteIp) form.append("remoteip", remoteIp);
+        const resp = await fetchImpl(TURNSTILE_SITEVERIFY_URL, { method: "POST", body: form });
+        const data = (await resp.json()) as { success?: boolean; "error-codes"?: string[] };
+        return { success: data.success === true, errorCodes: data["error-codes"] };
+    } catch {
+        return { success: false, errorCodes: ["verify-failed"] };
+    }
+}


### PR DESCRIPTION
Replaces the spoofable `mailto=ui@openalex.org` marker with an **unforgeable, short-TTL HMAC token** so the UI-vs-API analytics split (relied on by #338 and #340) stops being forgeable.

## What this does
- `POST /ui-token`: verifies a Cloudflare **Turnstile** solve server-side, mints a 30-min HMAC token.
- Main path: verifies the `X-OpenAlex-UI` header and tags analytics **`double7 = trustedUi`**.
- `src/uiToken.ts` + **11 unit tests** (forgery, tamper, expiry, fail-closed Turnstile). `tsc` clean, **99/99 tests pass**.

## Safety invariants
- **Provenance, never authorization.** A missing/expired/forged token NEVER blocks, throttles, or downgrades a request — it only flips an analytics flag. The API stays wide open.
- **Inert until provisioned.** With the secrets unset, `/ui-token` returns 503 and `trustedUi`=0. Already provisioned on prod: the dedicated Turnstile widget (sitekey `0x4AAAAAADgYVjKGNQI_Wrxm`) + Worker secrets `TURNSTILE_SECRET` and `UI_TOKEN_HMAC_SECRET` (`keep_vars:true` so they survive deploy).
- **Additive analytics.** `double7` is appended (AnalyticsEngine-positional-safe).

## ⚠️ Merging = prod deploy
This Worker auto-deploys from `main`. Merging ships it. The change is additive/inert (no behavior change until the GUI starts sending `X-OpenAlex-UI`), but it is a prod deploy.

## Follow-ups (not in this PR)
- GUI side (Turnstile widget + mint-fetch + send `X-OpenAlex-UI`, dual-emit `mailto`) — scaffolding next.
- Optional: per-IP rate-limit on `/ui-token` (Turnstile already gates minting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)